### PR TITLE
Split package and update to v0.2.1

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,3 +6,9 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About shimmy
-============
+About shimmy-split-feedstock
+============================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/shimmy-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/Farama-Foundation/Shimmy
 
 Package license: MIT
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/shimmy-feedstock/blob/main/LICENSE.txt)
 
 Summary: API for converting popular non-gymnasium environments to a gymnasium compatible environment.
 
@@ -28,27 +28,30 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-shimmy-green.svg)](https://anaconda.org/conda-forge/shimmy) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/shimmy.svg)](https://anaconda.org/conda-forge/shimmy) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/shimmy.svg)](https://anaconda.org/conda-forge/shimmy) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/shimmy.svg)](https://anaconda.org/conda-forge/shimmy) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-shimmy--all-green.svg)](https://anaconda.org/conda-forge/shimmy-all) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/shimmy-all.svg)](https://anaconda.org/conda-forge/shimmy-all) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/shimmy-all.svg)](https://anaconda.org/conda-forge/shimmy-all) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/shimmy-all.svg)](https://anaconda.org/conda-forge/shimmy-all) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-shimmy--atari-green.svg)](https://anaconda.org/conda-forge/shimmy-atari) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/shimmy-atari.svg)](https://anaconda.org/conda-forge/shimmy-atari) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/shimmy-atari.svg)](https://anaconda.org/conda-forge/shimmy-atari) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/shimmy-atari.svg)](https://anaconda.org/conda-forge/shimmy-atari) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-shimmy--gym-green.svg)](https://anaconda.org/conda-forge/shimmy-gym) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/shimmy-gym.svg)](https://anaconda.org/conda-forge/shimmy-gym) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/shimmy-gym.svg)](https://anaconda.org/conda-forge/shimmy-gym) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/shimmy-gym.svg)](https://anaconda.org/conda-forge/shimmy-gym) |
 
-Installing shimmy
-=================
+Installing shimmy-split
+=======================
 
-Installing `shimmy` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `shimmy-split` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `shimmy` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `shimmy, shimmy-all, shimmy-atari, shimmy-gym` can be installed with `conda`:
 
 ```
-conda install shimmy
+conda install shimmy shimmy-all shimmy-atari shimmy-gym
 ```
 
 or with `mamba`:
 
 ```
-mamba install shimmy
+mamba install shimmy shimmy-all shimmy-atari shimmy-gym
 ```
 
 It is possible to list all of the versions of `shimmy` available on your platform with `conda`:
@@ -118,17 +121,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating shimmy-feedstock
-=========================
+Updating shimmy-split-feedstock
+===============================
 
-If you would like to improve the shimmy recipe or build a new
+If you would like to improve the shimmy-split recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/shimmy-feedstock are
+Note that all branches in the conda-forge/shimmy-split-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/0001-skip-render-check-in-atari-test.patch
+++ b/recipe/0001-skip-render-check-in-atari-test.patch
@@ -1,0 +1,24 @@
+From 62729390afb9f7f7946cc789c512f679a22c0779 Mon Sep 17 00:00:00 2001
+From: Christof Kaufmann <christofkaufmann.dev@gmail.com>
+Date: Tue, 28 Mar 2023 14:07:53 +0200
+Subject: [PATCH] Skip render check again in atari test
+
+---
+ tests/test_atari.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/test_atari.py b/tests/test_atari.py
+index d5c756d..61dd503 100644
+--- a/tests/test_atari.py
++++ b/tests/test_atari.py
+@@ -39,7 +39,7 @@ def test_atari_envs(env_id):
+     env = gym.make(env_id)
+
+     with warnings.catch_warnings(record=True) as caught_warnings:
+-        check_env(env.unwrapped)
++        check_env(env.unwrapped, skip_render_check=True)
+
+     env.close()
+
+--
+2.34.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,9 +36,15 @@ outputs:
       host:
         - python >=3.7
         - pip
+        - gymnasium >=0.27.0
+        - cloudpickle
+        - jax-jumpy
+        - numpy >=1.18.0
+        - typing-extensions
       run:
         - python >=3.7
         - numpy >=1.18.0
+        - gymnasium >=0.27.0
     test:
       imports:
         - {{ name|lower }}
@@ -112,11 +118,10 @@ outputs:
       source_files:
         - tests/
       requires:
-        - python <=3.10
         - pytest
         - pip
       commands:
-        - pip install --no-cache-dir 'autorom[accept-rom-license]==0.6.0'
+        - pip install --no-cache-dir 'autorom[accept-rom-license]>=0.6.1'
         - pytest -v tests/test_atari.py
 
   - name: {{ name|lower }}-imageio

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,21 @@
 {% set name = "shimmy" %}
-{% set version = "0.1.0" %}
+{% set version = "0.2.1" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name|lower }}-split
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Shimmy-{{ version }}.tar.gz
-  sha256: deb0d396e8fd7702ed08997c7f3c23af9b422c1b04df8b0db9e3c5b15e2d473b
+  url: https://github.com/Farama-Foundation/Shimmy/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b15358d54e43e7d938e66aea70c099f4a45a90d67b0cbcb00f77b1a4fb9da1b2
+  patches:
+    - 0001-skip-render-check-in-atari-test.patch
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
 
+# Maybe need these up here for conda-smithy to handle them properly.
 requirements:
   host:
     - python >=3.7
@@ -21,15 +23,235 @@ requirements:
   run:
     - python >=3.7
     - numpy >=1.18.0
-    - gymnasium >=0.26.0
+    - gymnasium >=0.27.0
 
-test:
-  imports:
-    - shimmy
-  commands:
-    - pip check
-  requires:
-    - pip
+outputs:
+  - name: {{ name|lower }}
+    build:
+      noarch: python
+      script: {{ PYTHON }} -m pip install . -vv
+    requirements:
+      build:
+        - python >=3.7
+      host:
+        - python >=3.7
+        - pip
+      run:
+        - python >=3.7
+        - numpy >=1.18.0
+    test:
+      imports:
+        - {{ name|lower }}
+
+  - name: {{ name|lower }}-all
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('shimmy-gym', exact=True) }}
+        - {{ pin_subpackage('shimmy-atari', exact=True) }}
+        # see below
+        # - {{ pin_subpackage('shimmy-imageio', exact=True) }}
+        # see below
+        # - {{ pin_subpackage('shimmy-dm-control', exact=True) }}
+        # see below
+        # - {{ pin_subpackage('shimmy-dm-control-multi-agent', exact=True) }}
+        # see below
+        # - {{ pin_subpackage('shimmy-openspiel', exact=True) }}
+        # see below
+        # - {{ pin_subpackage('shimmy-meltingpot', exact=True) }}
+        # see below
+        # - {{ pin_subpackage('shimmy-bsuite', exact=True) }}
+    test:
+      imports:
+        - {{ name|lower }}
+      source_files:
+        - tests/
+      requires:
+        - pytest
+        - pip
+      commands:
+        - pip check
+
+  - name: {{ name|lower }}-gym
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('shimmy', exact=True) }}
+        - gym >=0.21
+    test:
+      imports:
+        - {{ name|lower }}
+      source_files:
+        - tests/
+      requires:
+        - pytest
+      commands:
+        - pytest -v tests/test_gym.py
+
+  - name: {{ name|lower }}-atari
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('shimmy', exact=True) }}
+        - ale-py >=0.8.1,<0.9
+    test:
+      imports:
+        - {{ name|lower }}
+      source_files:
+        - tests/
+      requires:
+        - python <=3.10
+        - pytest
+        - pip
+      commands:
+        - pip install --no-cache-dir 'autorom[accept-rom-license]==0.6.0'
+        - pytest -v tests/test_atari.py
+
+  - name: {{ name|lower }}-imageio
+    build:
+      # not sure if the name should be shimmy-imageio or rather shimmy-mujoco
+      skip: true
+      noarch: python
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('shimmy', exact=True) }}
+        - mujoco-python >=2.2.0,<2.4
+        - imageio >=2.14.1
+    test:
+      imports:
+        # There are no tests in the source code for shimmy-imageio or shimmy-mujoco
+
+  - name: {{ name|lower }}-dm-control
+    build:
+      # latest version of dm-control is 1.0.9 on conda-forge currently
+      skip: true
+      noarch: python
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('shimmy', exact=True) }}
+        - dm-control >=1.0.10
+        - imageio
+        - h5py >=3.7.0
+    test:
+      imports:
+        - {{ name|lower }}
+      source_files:
+        - tests/
+      requires:
+        - pytest
+      commands:
+        - pytest -v tests/test_dm_control.py
+
+  - name: {{ name|lower }}-dm-control-multi-agent
+    build:
+      # pettingzoo is not yet available on conda-forge
+      # latest version of dm-control is 1.0.9 on conda-forge currently
+      skip: true
+      noarch: python
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('shimmy', exact=True) }}
+        - dm-control >=1.0.10
+        - pettingzoo >=1.22.4
+    test:
+      imports:
+        - {{ name|lower }}
+      source_files:
+        - tests/
+      requires:
+        - pytest
+      commands:
+        - pytest -v tests/test_dm_control_multi_agent.py
+
+  - name: {{ name|lower }}-openspiel
+    build:
+      # open_spiel and pettingzoo are not yet available on conda-forge
+      skip: true
+      noarch: python
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('shimmy', exact=True) }}
+        - open_spiel >=1.2
+        - pettingzoo >=1.22.4
+    test:
+      imports:
+        - {{ name|lower }}
+      source_files:
+        - tests/
+      requires:
+        - pytest
+      commands:
+        - pytest -v tests/test_openspiel.py
+
+  - name: {{ name|lower }}-meltingpot
+    build:
+      # pettingzoo is not yet available on conda-forge
+      skip: true
+      noarch: python
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('shimmy', exact=True) }}
+        - pettingzoo >=1.22.4
+    test:
+      imports:
+        - {{ name|lower }}
+      source_files:
+        - tests/
+      requires:
+        - pytest
+        # test will be skipped without meltingpot, but it is not yet available on conda-forge
+        # - meltingpot
+      commands:
+        - pytest -v tests/test_meltingpot.py
+
+  - name: {{ name|lower }}-bsuite
+    build:
+      # bsuite is not yet available on conda-forge
+      skip: true
+      noarch: python
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('shimmy', exact=True) }}
+        - bsuite >=0.3.5
+    test:
+      imports:
+        - {{ name|lower }}
+      source_files:
+        - tests/
+      requires:
+        - pytest
+      commands:
+        - pytest -v tests/test_bsuite.py
 
 about:
   home: https://github.com/Farama-Foundation/Shimmy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ outputs:
   - name: {{ name|lower }}
     build:
       noarch: python
-      script: {{ PYTHON }} -m pip install . -vv
+      script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
     requirements:
       build:
         - python >=3.7


### PR DESCRIPTION
The revised recipe splits up the package according to the subpackages of the PyPI package. Currently only the subpackages `shimmy-gym` and `shimmy-atari` are available. The tests required a patch to skip the rendering, which is not available without additional work during build.

The other subpackages have been prepared, but their builds are skipped mainly due to missing dependencies on conda-forge.

Overall the recipe is analog to the Gymnasium feedstock recipe.

Note: `shimmy-atari` is a dependency of `gymnasium-atari`, which is currently disabled and can be enabled, when this PR is accepted, see https://github.com/conda-forge/gymnasium-feedstock/pull/16.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

